### PR TITLE
Fix and simplify `PardisoSolver::set_pattern`

### DIFF
--- a/src/Newton.cpp
+++ b/src/Newton.cpp
@@ -62,22 +62,12 @@ void Newton::initialize()
 {
 	eval_fgh(m_x, f, g, h);
 	
-	
 	IId = energy->symDirichlet.II;
 	JJd = energy->symDirichlet.JJ;
 	SSd = energy->symDirichlet.SS;
-
-    // convert to eigen triplets
-    std::vector<Eigen::Triplet<double>> triplets;
-    triplets.reserve(IId.size());
-    for (size_t i = 0; i < IId.size(); ++i) {
-        triplets.emplace_back(IId[i], JJd[i], SSd[i]);
-    }
     
     // Create sparse matrix (assuming you want a square matrix)
     MKL_INT n = *std::max_element(IId.begin(), IId.end()) + 1;
-    Eigen::SparseMatrix<double> sparse_matrix(n, n);
-    sparse_matrix.setFromTriplets(triplets.begin(), triplets.end());
 
 	// find pattern for initialization
 	II.insert(II.end(), IId.begin(), IId.end());
@@ -106,7 +96,6 @@ double Newton::eval_ls(Mat& x)
 {
 	double f;
 	Vec g;
-	SpMat h;
 	Vec vec_x = Eigen::Map<Vec>(x.data(), x.rows()  * x.cols(), 1);
 	eval_f(vec_x, f);
 	return f;


### PR DESCRIPTION
The index array `SRC_I` written by `igl::unique_row(SRC, DST, SRC_I, _)` apparently does not necessarily contain the index of the *first* row in `SRC` that corresponds to each row in `DST`; this likely caused by the unnecessary additional call to `igl::sort_rows` made by `igl::unique_row` not using a stable sort. The consequence was that the binning of triplet indices into the `iis` buckets was slightly off, leading to incorrect assembled Hessian values.

This commit reimplements the construction of (`ia`, `ja`, and `iis`) using a slightly simpler and more efficient approach that does not call `unique_rows`. It also removes some dead code.